### PR TITLE
Replace "destroy" with "removeAllListeners", update README and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ eventEmitter.off('chat', handler);
 
 #### `removeAllListeners(event?: string): void`
 
-Removes all listeners for a specific event or all events if no event is specified.
+Removes all listeners for a specific event or all events if no event is specified. This method replaces the previous `destroy` method, as it now handles the same functionality.
 
 ```typescript
 eventEmitter.removeAllListeners('chat');
@@ -142,14 +142,18 @@ instance.on('done', (message) => {
 instance.doSomething();
 ```
 
-### Destroying the Event Emitter
+### Destroying the Event Emitter (Deprecated)
 
 #### `destroy(): void`
 
-Removes all listeners and cleans up the event emitter.
+> **Deprecated:** This method has been replaced by `removeAllListeners()`. Use `removeAllListeners()` to achieve the same functionality.
 
 ```typescript
+// Deprecated
 eventEmitter.destroy();
+
+// Recommended
+eventEmitter.removeAllListeners();
 ```
 
 ## Benchmark Results

--- a/__tests__/CozyEvent.test.ts
+++ b/__tests__/CozyEvent.test.ts
@@ -8,7 +8,7 @@ describe('CozyEvent', () => {
   });
 
   afterEach(() => {
-    emitter.destroy();
+    emitter.removeAllListeners();
     emitter = null;
   });
 
@@ -89,7 +89,7 @@ describe('CozyEvent', () => {
   test('should destroy: emitSync should not throw exeption', async () => {
     const mockFn = jest.fn();
     emitter.on('asyncEvent', mockFn);
-    emitter.destroy();
+    emitter.removeAllListeners();
     emitter.emit('asyncEvent', 'Oh look at me, look at me');
     expect(mockFn).not.toHaveBeenCalledWith('Oh look at me, look at me');
   });
@@ -97,7 +97,7 @@ describe('CozyEvent', () => {
   test('should destroy: emitAsync should not throw exeption', async () => {
     const mockFn = jest.fn();
     emitter.on('asyncEvent', mockFn);
-    emitter.destroy();
+    emitter.removeAllListeners();
     emitter.emitAsync('asyncEvent', 'Imma event!');
     expect(mockFn).not.toHaveBeenCalledWith('Imma event!');
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cozyevent",
-  "version": "1.1.5",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cozyevent",
-      "version": "1.1.5",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@braintree/event-emitter": "^2.0.2",
@@ -231,14 +231,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -534,11 +533,10 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"

--- a/src/core/CozyEvent.ts
+++ b/src/core/CozyEvent.ts
@@ -76,12 +76,11 @@ class CozyEvent {
    * @param event - (Optional) The name of the event to remove listeners for.
    */
   public removeAllListeners(event?: string): void {
-    event ? delete this._events[event] : (this._events = {});
-  }
-
-  public destroy(): void {
-    this.removeAllListeners();
-    this._events = {};
+    if (event) {
+      delete this._events[event];
+    } else {
+      this._events = {};
+    }
   }
 }
 

--- a/src/core/CozyEvent.ts
+++ b/src/core/CozyEvent.ts
@@ -76,11 +76,7 @@ class CozyEvent {
    * @param event - (Optional) The name of the event to remove listeners for.
    */
   public removeAllListeners(event?: string): void {
-    if (event) {
-      delete this._events[event];
-    } else {
-      this._events = {};
-    }
+    event ? delete this._events[event] : this._events = {};
   }
 }
 


### PR DESCRIPTION
This pull request addresses redundancy  in event listener management by deprecating the destroy method and using removeAllListeners exclusively. The following changes have been made:

- Removed Redundancy: Eliminated the destroy method, relying solely on removeAllListeners for removing event listeners.
- Documentation Update: Updated the README to mark destroy as deprecated and provided guidance on using removeAllListeners instead.
- Test Modifications: Updated tests that were still using destroy to now use removeAllListeners. All tests have been run and passed successfully.

Please review the changes and let me know if any further modifications are needed.